### PR TITLE
Removed second return declaration in the MyView::render() method.

### DIFF
--- a/src/ResqueBoard/View/MyView.php
+++ b/src/ResqueBoard/View/MyView.php
@@ -55,7 +55,6 @@ class MyView extends \Slim\View
             require $this->templatesDirectory . DIRECTORY_SEPARATOR . $this->footerTemplate;
         }
         return ob_get_clean();
-        return $content;
     }
 }
 


### PR DESCRIPTION
Hi there,

I guess second return statement is not necessary in the MyView::render() method as content will be returned by ob_get_clean() function. 
