### PR TITLE
Update ResqueStat.php

### DIFF
--- a/src/ResqueBoard/Lib/ResqueStat.php
+++ b/src/ResqueBoard/Lib/ResqueStat.php
@@ -517,10 +517,13 @@ class ResqueStat
         }
 
 
+        $pendingJobs = [];
         foreach ($queues as $queue => $jobs) {
             for ($i = count($jobs)-1; $i >= 0; $i--) {
                 $jobs[$i] = json_decode($jobs[$i], true);
-                $jobs[$i] = array(
+                $pendingJobs[] = array_merge(
+                    $jobs[$i]
+                    ,array(
                     'd' => array(
                         'args' => array(
                             'queue' => $queue,
@@ -531,11 +534,11 @@ class ResqueStat
                                 )
                             )
                         )
-                    );
+                    ));
             }
         }
-
-        $jobs = $this->formatJobs($jobs);
+        
+        $jobs = $this->formatJobs($pendingJobs);
         array_walk(
             $jobs,
             function (&$j) {


### PR DESCRIPTION
Putting to work the pending jobs having multiple queues (you were overriding the pending jobs of multiple queues, for example:

queue 1 has job 1 and 2
queue 2 has none job

output by original code:
empty

because queue 2 jobs will override the index $i and set jobs array to none

SOLUTION:
Create a separated array which contain all that jobs
