### PR TITLE
fixed "BadValue $in needs an array" bug present in mongo 2.6

### DIFF
--- a/src/ResqueBoard/Lib/ResqueStat.php
+++ b/src/ResqueBoard/Lib/ResqueStat.php
@@ -85,7 +85,7 @@ class ResqueStat
         } else {
             return false;
         }
-		
+
         foreach ($stats as $key => $value) {
             $stats[$key] = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], $validType[$key] . '_events')->count();
         }

--- a/src/ResqueBoard/Lib/ResqueStat.php
+++ b/src/ResqueBoard/Lib/ResqueStat.php
@@ -86,8 +86,6 @@ class ResqueStat
             return false;
         }
 		
-        array_values($stats);
-        
         foreach ($stats as $key => $value) {
             $stats[$key] = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], $validType[$key] . '_events')->count();
         }
@@ -908,7 +906,7 @@ class ResqueStat
 
 
 
-        $jobsCursor = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], 'done_events')->find(array('d.job_id' => array('$in' => $jobIds)));
+        $jobsCursor = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], 'done_events')->find(array('d.job_id' => array('$in' => array_values($jobIds))));
         foreach ($jobsCursor as $successJob) {
             $jobs[$successJob['d']['job_id']]['status'] = self::JOB_STATUS_COMPLETE;
             $jobs[$successJob['d']['job_id']]['took'] = $successJob['d']['time'];
@@ -917,7 +915,7 @@ class ResqueStat
 
         if (!empty($jobIds)) {
 
-            $jobsCursor = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], 'fail_events')->find(array('d.job_id' => array('$in' => $jobIds)));
+            $jobsCursor = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], 'fail_events')->find(array('d.job_id' => array('$in' => array_values($jobIds))));
             $pipelineCommands = array();
             foreach ($jobsCursor as $failedJob) {
                 $jobs[$failedJob['d']['job_id']]['status'] = self::JOB_STATUS_FAILED;
@@ -937,7 +935,7 @@ class ResqueStat
         }
 
         if (!empty($jobIds)) {
-            $jobsCursor = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], 'process_events')->find(array('d.job_id' => array('$in' => $jobIds)));
+            $jobsCursor = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], 'process_events')->find(array('d.job_id' => array('$in' => array_values($jobIds))));
             foreach ($jobsCursor as $processJob) {
                 $jobs[$processJob['d']['job_id']]['status'] = self::JOB_STATUS_RUNNING;
                 unset($jobIds[array_search($processJob['d']['job_id'], $jobIds)]);

--- a/src/ResqueBoard/Lib/ResqueStat.php
+++ b/src/ResqueBoard/Lib/ResqueStat.php
@@ -85,7 +85,9 @@ class ResqueStat
         } else {
             return false;
         }
-
+		
+        array_values($stats);
+        
         foreach ($stats as $key => $value) {
             $stats[$key] = Service::Mongo()->selectCollection(Service::$settings['Mongo']['database'], $validType[$key] . '_events')->count();
         }


### PR DESCRIPTION
Hey,

Fixed a bug related to mongodb 2.6. When navigating to the /jobs/view page I would get "Can't canonicalize query: BadValue $in needs an array". The reason for this is because the $stats array started at 1 when it should have started at 0. I run $stats through array_values() which resets the key values. Mongodb 2.4 is more lenient hence you do not see this error.

@see https://stackoverflow.com/questions/22748000/mongodb-2-6-0-rc2-and-php-1-4-5-find-id-in
