### PR TITLE
array init syntax fix.(php 5.3 format)

### DIFF
--- a/src/ResqueBoard/Lib/ResqueStat.php
+++ b/src/ResqueBoard/Lib/ResqueStat.php
@@ -517,7 +517,7 @@ class ResqueStat
         }
 
 
-        $pendingJobs = [];
+        $pendingJobs = array();
         foreach ($queues as $queue => $jobs) {
             for ($i = count($jobs)-1; $i >= 0; $i--) {
                 $jobs[$i] = json_decode($jobs[$i], true);


### PR DESCRIPTION
An error occurred by the environment of "CentOS 6.6 (php-5.3.3-40)", so it was corrected.
